### PR TITLE
Expose PlaysoundException, remove unused urllib.error from imports

### DIFF
--- a/playsound3/__init__.py
+++ b/playsound3/__init__.py
@@ -2,13 +2,7 @@ __license__ = "MIT"
 __version__ = "3.2.7"
 __author__ = "Szymon Mikler"
 
-from playsound3.playsound3 import (
-    AVAILABLE_BACKENDS,
-    DEFAULT_BACKEND,
-    playsound,
-    prefer_backends,
-    PlaysoundException
-)
+from playsound3.playsound3 import AVAILABLE_BACKENDS, DEFAULT_BACKEND, PlaysoundException, playsound, prefer_backends
 
 __all__ = [
     "AVAILABLE_BACKENDS",

--- a/playsound3/__init__.py
+++ b/playsound3/__init__.py
@@ -7,6 +7,7 @@ from playsound3.playsound3 import (
     DEFAULT_BACKEND,
     playsound,
     prefer_backends,
+    PlaysoundException
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "DEFAULT_BACKEND",
     "playsound",
     "prefer_backends",
+    "PlaysoundException"
 ]

--- a/playsound3/__init__.py
+++ b/playsound3/__init__.py
@@ -4,10 +4,4 @@ __author__ = "Szymon Mikler"
 
 from playsound3.playsound3 import AVAILABLE_BACKENDS, DEFAULT_BACKEND, PlaysoundException, playsound, prefer_backends
 
-__all__ = [
-    "AVAILABLE_BACKENDS",
-    "DEFAULT_BACKEND",
-    "playsound",
-    "prefer_backends",
-    "PlaysoundException"
-]
+__all__ = ["AVAILABLE_BACKENDS", "DEFAULT_BACKEND", "playsound", "prefer_backends", "PlaysoundException"]

--- a/playsound3/playsound3.py
+++ b/playsound3/playsound3.py
@@ -7,7 +7,6 @@ import shutil
 import signal
 import subprocess
 import tempfile
-import urllib.error
 import urllib.request
 from abc import ABC, abstractmethod
 from importlib.util import find_spec
@@ -40,11 +39,9 @@ def _download_sound_from_web(link: str, destination: Path) -> None:
     # Identifies itself as a browser to avoid HTTP 403 errors
     headers = {"User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"}
     request = urllib.request.Request(link, headers=headers)
-    try:
-        with urllib.request.urlopen(request) as response, destination.open("wb") as out_file:
-            out_file.write(response.read())
-    except (urllib.error.URLError, urllib.error.HTTPError):
-        raise PlaysoundException(f"URL at {link} is unreachable")
+
+    with urllib.request.urlopen(request) as response, destination.open("wb") as out_file:
+        out_file.write(response.read())
 
 
 def _prepare_path(sound: str | Path) -> str:

--- a/playsound3/playsound3.py
+++ b/playsound3/playsound3.py
@@ -40,9 +40,11 @@ def _download_sound_from_web(link: str, destination: Path) -> None:
     # Identifies itself as a browser to avoid HTTP 403 errors
     headers = {"User-Agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"}
     request = urllib.request.Request(link, headers=headers)
-
-    with urllib.request.urlopen(request) as response, destination.open("wb") as out_file:
-        out_file.write(response.read())
+    try:
+        with urllib.request.urlopen(request) as response, destination.open("wb") as out_file:
+            out_file.write(response.read())
+    except (urllib.error.URLError, urllib.error.HTTPError):
+        raise PlaysoundException(f"URL at {link} is unreachable")
 
 
 def _prepare_path(sound: str | Path) -> str:


### PR DESCRIPTION
Added `PlaysoundException` to imports to allow exception handling, removed unused `urllib.error` import.